### PR TITLE
Add message for switching between servers

### DIFF
--- a/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
+++ b/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
@@ -34,6 +34,7 @@ public enum LocaleMessage {
 
     CONNECT_JOIN_MESSAGE("&b{0} &7joined the network"),
     CONNECT_QUIT_MESSAGE("&b{0} &7left the network"),
+    SWITCH_SERVER_MESSAGE("&b{0} &7switched to {1}"),
 
     FIND_MESSAGE("&b{0} &7is connected to &b{1}"),
 

--- a/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageHandler.java
+++ b/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageHandler.java
@@ -27,6 +27,7 @@ package me.crypnotic.neutron.module.connectmessage;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.PostLoginEvent;
+import com.velocitypowered.api.event.player.ServerConnectedEvent;
 
 import lombok.RequiredArgsConstructor;
 import me.crypnotic.neutron.api.locale.LocaleMessage;
@@ -54,5 +55,15 @@ public class ConnectMessageHandler {
         }
 
         StringHelper.broadcast(module.getNeutron().getProxy().getAllPlayers(), LocaleMessage.CONNECT_QUIT_MESSAGE, event.getPlayer().getUsername());
+    }
+
+
+    @Subscribe
+    public void onPlayerSwitchServer(ServerConnectedEvent event) {
+        if (config.isAllowSilentJoinQuit() && event.getPlayer().hasPermission("neutron.silentquit")) {
+            return;
+        }
+
+        StringHelper.broadcast(module.getNeutron().getProxy().getAllPlayers(), LocaleMessage.SWITCH_SERVER_MESSAGE, event.getPlayer().getUsername(), event.getServer().getServerInfo().getName());
     }
 }

--- a/src/main/resources/locales/en_US.conf
+++ b/src/main/resources/locales/en_US.conf
@@ -2,6 +2,7 @@ alert_message = "&7&l[&c&lALERT&7&l] &e{0}"
 
 connect_join_message = "&b{0} &7joined the network"
 connect_quit_message = "&b{0} &7left the network"
+switch_server_message = "&b{0} &7switched to {1}"
 
 find_message = "&b{0} &7is connected to &b{1}"
 


### PR DESCRIPTION
This pull request simply adds a message indicating when a player switches between servers.

It also currently displays the message when the player first joins the server. I'm not sure if this should be intended behaviour or not, because the intended implementation of this was to replace the join messages on the server-side. Perhaps editing the join message on the proxy to include the joined server would be a good idea?

This is my first foray into Velocity, so I'm excited to hear comments on if I approached this correctly.